### PR TITLE
Allow deleting properties from state

### DIFF
--- a/.changeset/two-cheetahs-behave.md
+++ b/.changeset/two-cheetahs-behave.md
@@ -1,0 +1,5 @@
+---
+"@udecode/zustood": patch
+---
+
+Allow deleting properties from state

--- a/packages/zustood/src/createStore.spec.ts
+++ b/packages/zustood/src/createStore.spec.ts
@@ -76,5 +76,22 @@ describe('zustood', () => {
         stars: 1,
       });
     });
+
+    describe('deletes a property', () => {
+      it('should delete that property', () => {
+        const store = createStore('repo')<{ name?: string; stars: number }>({
+          name: 'zustood',
+          stars: 0,
+        });
+
+        store.set.state((draft) => {
+          delete draft.name;
+        });
+
+        expect(store.get.state()).toEqual({
+          stars: 0,
+        });
+      });
+    });
   });
 });

--- a/packages/zustood/src/middlewares/immer.middleware.ts
+++ b/packages/zustood/src/middlewares/immer.middleware.ts
@@ -1,13 +1,14 @@
 import produce from 'immer';
-import { State, StateCreator } from 'zustand';
+import { GetState, State, StateCreator } from 'zustand';
 import { SetImmerState } from '../types';
 
 export const immerMiddleware =
   <T extends State>(
-    config: StateCreator<T>
-  ): StateCreator<T, SetImmerState<T>> =>
+    config: StateCreator<T, SetImmerState<T>, GetState<T>>
+  ): StateCreator<T> =>
   (set, get, api) => {
-    api.setState = (fn) => set(produce<T>(fn as any) as any);
+    const setState: SetImmerState<T> = (fn) => set(produce<T>(fn), true);
+    api.setState = setState as any;
 
-    return config(api.setState, get, api);
+    return config(setState, get, api);
   };


### PR DESCRIPTION
**Description**

plate tried to remove editor state on unmount (https://github.com/udecode/plate/blob/ebc85b088c18a1c7e67fa9ed9ec78de7772898fa/packages/core/src/stores/plate/platesStore.ts#L28-L30) but the state was not deleted.

The reason is by default, zustand `set` tries to merge state instead of replacing old state with the new one. Set the second agrument of `set` to true would fix this problem.