### PR TITLE
fix extendActions get type

### DIFF
--- a/.changeset/fluffy-snakes-double.md
+++ b/.changeset/fluffy-snakes-double.md
@@ -1,0 +1,7 @@
+---
+"@udecode/zustood": patch
+---
+
+fix: extended actions `get` parameter was missing the extended selectors.
+
+

--- a/packages/zustood/src/types.ts
+++ b/packages/zustood/src/types.ts
@@ -32,7 +32,9 @@ export type StoreApi<
     TSelectors & ReturnType<SB>
   >;
 
-  extendActions<AB extends ActionBuilder<TName, T, StateActions<T> & TActions>>(
+  extendActions<
+    AB extends ActionBuilder<TName, T, StateActions<T> & TActions, TSelectors>
+  >(
     builder: AB
   ): StoreApi<
     TName,


### PR DESCRIPTION
**Description**

Extended actions `get` parameter is now properly typed.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->
