### PR TITLE
add enable map set option to immer's options

### DIFF
--- a/.changeset/many-otters-applaud.md
+++ b/.changeset/many-otters-applaud.md
@@ -1,0 +1,5 @@
+---
+'@udecode/zustood': patch
+---
+
+Add enable map set to immer's options

--- a/packages/zustood/src/createStore.ts
+++ b/packages/zustood/src/createStore.ts
@@ -36,7 +36,7 @@ export const createStore =
     } = options;
 
     setAutoFreeze(immer?.enabledAutoFreeze ?? false);
-    if(immer?.enableMapSet) {
+    if (immer?.enableMapSet) {
       enableMapSet();
     }
 

--- a/packages/zustood/src/createStore.ts
+++ b/packages/zustood/src/createStore.ts
@@ -1,4 +1,4 @@
-import { setAutoFreeze } from 'immer';
+import { setAutoFreeze, enableMapSet } from 'immer';
 import create, { State, StateCreator } from 'zustand';
 import {
   devtools as devtoolsMiddleware,
@@ -36,6 +36,9 @@ export const createStore =
     } = options;
 
     setAutoFreeze(immer?.enabledAutoFreeze ?? false);
+    if(immer?.enableMapSet) {
+      enableMapSet();
+    }
 
     const middlewares: any[] = [immerMiddleware, ..._middlewares];
 

--- a/packages/zustood/src/types/ImmerOptions.ts
+++ b/packages/zustood/src/types/ImmerOptions.ts
@@ -3,4 +3,5 @@ export interface ImmerOptions {
    * Enable autofreeze.
    */
   enabledAutoFreeze?: boolean;
+  enableMapSet?: boolean;
 }


### PR DESCRIPTION
**Description**
Allow working with es6 maps inside the store.

A fix for this issue: https://github.com/udecode/zustood/issues/27
