### PR TITLE
[Feat]: Support logging action name when devtools enabled

### DIFF
--- a/.changeset/polite-donkeys-refuse.md
+++ b/.changeset/polite-donkeys-refuse.md
@@ -1,0 +1,5 @@
+---
+"@udecode/zustood": minor
+---
+
+Support logging action name when devtools enabled

--- a/packages/zustood/package.json
+++ b/packages/zustood/package.json
@@ -30,7 +30,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "immer": "9.0.6"
+    "immer": "^9.0.6"
   },
   "peerDependencies": {
     "zustand": ">=3.5.10"

--- a/packages/zustood/src/createStore.ts
+++ b/packages/zustood/src/createStore.ts
@@ -64,10 +64,14 @@ export const createStore =
 
     const stateActions = generateStateActions(useStore, name);
 
-    const mergeState: MergeState<T> = (state) => {
+    const mergeState: MergeState<T> = (state, actionName) => {
       store.setState((draft) => {
         Object.assign(draft, state);
-      });
+      }, actionName || `@@${name}/mergeState`);
+    };
+
+    const setState: SetImmerState<T> = (fn, actionName) => {
+      store.setState(fn, actionName || `@@${name}/setState`);
     };
 
     const hookSelectors = generateStateHookSelectors(useStore);
@@ -80,7 +84,7 @@ export const createStore =
       } as StateGetters<T>,
       name,
       set: {
-        state: store.setState,
+        state: setState,
         mergeState,
         ...stateActions,
       } as StateActions<T>,

--- a/packages/zustood/src/createStore.ts
+++ b/packages/zustood/src/createStore.ts
@@ -62,7 +62,7 @@ export const createStore =
     const store = createStore(() => initialState);
     const useStore = create(store as any) as UseImmerStore<T>;
 
-    const stateActions = generateStateActions(useStore);
+    const stateActions = generateStateActions(useStore, name);
 
     const mergeState: MergeState<T> = (state) => {
       store.setState((draft) => {

--- a/packages/zustood/src/middlewares/immer.middleware.ts
+++ b/packages/zustood/src/middlewares/immer.middleware.ts
@@ -7,7 +7,8 @@ export const immerMiddleware =
     config: StateCreatorWithDevtools<T, SetImmerState<T>, GetState<T>>
   ): StateCreatorWithDevtools<T> =>
   (set, get, api) => {
-    const setState: SetImmerState<T> = (fn, name) => set(produce<T>(fn), true, name);
+    const setState: SetImmerState<T> = (fn, actionName) =>
+      set(produce<T>(fn), true, actionName);
     api.setState = setState as any;
 
     return config(setState, get, api);

--- a/packages/zustood/src/middlewares/immer.middleware.ts
+++ b/packages/zustood/src/middlewares/immer.middleware.ts
@@ -1,13 +1,13 @@
 import produce from 'immer';
-import { GetState, State, StateCreator } from 'zustand';
-import { SetImmerState } from '../types';
+import { GetState, State } from 'zustand';
+import { SetImmerState, StateCreatorWithDevtools } from '../types';
 
 export const immerMiddleware =
   <T extends State>(
-    config: StateCreator<T, SetImmerState<T>, GetState<T>>
-  ): StateCreator<T> =>
+    config: StateCreatorWithDevtools<T, SetImmerState<T>, GetState<T>>
+  ): StateCreatorWithDevtools<T> =>
   (set, get, api) => {
-    const setState: SetImmerState<T> = (fn) => set(produce<T>(fn), true);
+    const setState: SetImmerState<T> = (fn, name) => set(produce<T>(fn), true, name);
     api.setState = setState as any;
 
     return config(setState, get, api);

--- a/packages/zustood/src/types.ts
+++ b/packages/zustood/src/types.ts
@@ -1,6 +1,7 @@
 import { Draft } from 'immer';
 import { State, StoreApi as RawStoreApi, UseStore } from 'zustand';
 import { EqualityChecker, GetState, StateSelector } from 'zustand/vanilla';
+import { NamedSet } from 'zustand/middleware'
 
 export type StoreApiGet<
   T extends State = {},
@@ -87,7 +88,9 @@ export type ActionBuilder<
   api: StoreApi<TName, T, TActions, TSelectors>
 ) => any;
 
-export type SetImmerState<T> = (fn: (draft: Draft<T>) => void) => void;
+export type SetImmerState<T> = (fn: (draft: Draft<T>) => void, name?: string) => void;
+
+export type StateCreatorWithDevtools<T extends State, CustomSetState = NamedSet<T>, CustomGetState = GetState<T>, CustomStoreApi extends RawStoreApi<T> = RawStoreApi<T>> = (set: CustomSetState, get: CustomGetState, api: CustomStoreApi) => T;
 
 export interface ImmerStoreApi<T extends State>
   extends Omit<RawStoreApi<T>, 'setState'> {

--- a/packages/zustood/src/types.ts
+++ b/packages/zustood/src/types.ts
@@ -1,7 +1,7 @@
 import { Draft } from 'immer';
 import { State, StoreApi as RawStoreApi, UseStore } from 'zustand';
 import { EqualityChecker, GetState, StateSelector } from 'zustand/vanilla';
-import { NamedSet } from 'zustand/middleware'
+import { NamedSet } from 'zustand/middleware';
 
 export type StoreApiGet<
   T extends State = {},
@@ -54,7 +54,10 @@ export type StoreApi<
   //   >;
 };
 
-export type MergeState<T extends State> = (state: Partial<T>) => void;
+export type MergeState<T extends State> = (
+  state: Partial<T>,
+  actionName?: string
+) => void;
 
 export type StateActions<T extends State> = SetRecord<T> & {
   state: SetImmerState<T>;
@@ -88,9 +91,17 @@ export type ActionBuilder<
   api: StoreApi<TName, T, TActions, TSelectors>
 ) => any;
 
-export type SetImmerState<T> = (fn: (draft: Draft<T>) => void, name?: string) => void;
+export type SetImmerState<T> = (
+  fn: (draft: Draft<T>) => void,
+  actionName?: string
+) => void;
 
-export type StateCreatorWithDevtools<T extends State, CustomSetState = NamedSet<T>, CustomGetState = GetState<T>, CustomStoreApi extends RawStoreApi<T> = RawStoreApi<T>> = (set: CustomSetState, get: CustomGetState, api: CustomStoreApi) => T;
+export type StateCreatorWithDevtools<
+  T extends State,
+  CustomSetState = NamedSet<T>,
+  CustomGetState = GetState<T>,
+  CustomStoreApi extends RawStoreApi<T> = RawStoreApi<T>
+> = (set: CustomSetState, get: CustomGetState, api: CustomStoreApi) => T;
 
 export interface ImmerStoreApi<T extends State>
   extends Omit<RawStoreApi<T>, 'setState'> {

--- a/packages/zustood/src/utils/generateStateActions.ts
+++ b/packages/zustood/src/utils/generateStateActions.ts
@@ -2,7 +2,8 @@ import { State } from 'zustand';
 import { SetRecord, UseImmerStore } from '../types';
 
 export const generateStateActions = <T extends State>(
-  store: UseImmerStore<T>
+  store: UseImmerStore<T>,
+  storeName: string
 ) => {
   const actions: SetRecord<T> = {} as any;
 
@@ -11,9 +12,10 @@ export const generateStateActions = <T extends State>(
       const prevValue = store.getState()[key];
       if (prevValue === value) return;
 
-      store.setState((draft) => {
+      const actionKey = key.replace(/^\S/, s => s.toUpperCase());
+      store.setState(((draft) => {
         draft[key] = value;
-      });
+      }), `${storeName}/${actionKey}`);
     };
   });
 

--- a/packages/zustood/src/utils/generateStateActions.ts
+++ b/packages/zustood/src/utils/generateStateActions.ts
@@ -12,10 +12,10 @@ export const generateStateActions = <T extends State>(
       const prevValue = store.getState()[key];
       if (prevValue === value) return;
 
-      const actionKey = key.replace(/^\S/, s => s.toUpperCase());
-      store.setState(((draft) => {
+      const actionKey = key.replace(/^\S/, (s) => s.toUpperCase());
+      store.setState((draft) => {
         draft[key] = value;
-      }), `${storeName}/${actionKey}`);
+      }, `@@${storeName}/set${actionKey}`);
     };
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3584,7 +3584,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@udecode/zustood@workspace:packages/zustood"
   dependencies:
-    immer: 9.0.6
+    immer: ^9.0.6
   peerDependencies:
     zustand: ">=3.5.10"
   languageName: unknown
@@ -7833,10 +7833,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:9.0.6":
-  version: 9.0.6
-  resolution: "immer@npm:9.0.6"
-  checksum: 75da22f3b32f3f14604eb389b4f50e84a14f2e42f306f0cbe4d2969aed54ec7fda9a7e9ca42ebae2ba73ec9bb6ec1001fafbac535accaf03860054ab0f7e8388
+"immer@npm:^9.0.6":
+  version: 9.0.12
+  resolution: "immer@npm:9.0.12"
+  checksum: bcbec6d76dac65e49068eb67ece4d407116e62b8cde3126aa89c801e408f5047763ba0aeb62f1938c1aa704bb6612f1d8302bb2a86fa1fc60fcc12d8b25dc895
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Description**

logging actions is supported by [zustand](https://github.com/pmndrs/zustand#logging-actions), but zustood do not pass the third action name arguments in [immer middleware](https://github.com/udecode/zustood/blob/main/packages/zustood/src/middlewares/immer.middleware.ts#L10), so i think it would be better if we can supporting it.
