### PR TITLE
[Feat]: selector hooks support passing equality function

### DIFF
--- a/.changeset/blue-coins-hang.md
+++ b/.changeset/blue-coins-hang.md
@@ -1,0 +1,5 @@
+---
+"@udecode/zustood": minor
+---
+
+selector hooks support passing equality function

--- a/.changeset/blue-coins-hang.md
+++ b/.changeset/blue-coins-hang.md
@@ -1,5 +1,5 @@
 ---
-"@udecode/zustood": minor
+"@udecode/zustood": major
 ---
 
 selector hooks support passing equality function

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ full typescript support:
 const repoStore = createStore('repo')({
   name: 'zustood ',
   stars: 0,
+  middlewares: ['immer', 'devtools', 'persist']
 })
   .extendSelectors((set, get, api) => ({
     validName: () => get.name().trim(),
@@ -191,8 +192,14 @@ export const actions = mapValuesKey('set', rootStore);
 ### Global hook selectors
 
 ```ts
+import shallow from 'zustand/shallow'
+
 useStore().repo.name()
 useStore().modal.isOpen()
+
+// prevent unnecessary re-renders
+// more see: https://docs.pmnd.rs/zustand/recipes#selecting-multiple-state-slices
+useStore().repo.middlewares(shallow)
 ```
 
 By using `useStore()`, ESLint will correctly lint hook errors.

--- a/packages/zustood/src/types.ts
+++ b/packages/zustood/src/types.ts
@@ -112,13 +112,13 @@ export interface UseImmerStore<T extends State>
   extends Omit<UseStore<T>, 'setState'> {
   (): T;
 
-  <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): U;
+  <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<T>): U;
 
   setState: SetImmerState<T>;
 }
 
 export type GetRecord<O> = {
-  [K in keyof O]: () => O[K];
+  [K in keyof O]: (equalityFn?: EqualityChecker<O>) => O[K];
 };
 export type SetRecord<O> = {
   [K in keyof O]: (value: O[K]) => void;

--- a/packages/zustood/src/utils/generateStateHookSelectors.ts
+++ b/packages/zustood/src/utils/generateStateHookSelectors.ts
@@ -1,4 +1,4 @@
-import { State } from 'zustand';
+import { EqualityChecker, State } from 'zustand';
 import { GetRecord, UseImmerStore } from '../types';
 
 export const generateStateHookSelectors = <T extends State>(
@@ -8,7 +8,9 @@ export const generateStateHookSelectors = <T extends State>(
 
   Object.keys(store.getState()).forEach((key) => {
     // selectors[`use${capitalize(key)}`] = () =>
-    selectors[key] = () => store((state: T) => state[key as keyof T]);
+    selectors[key] = (equalityFn?: EqualityChecker<T>) => {
+      return store((state: T) => state[key as keyof T], equalityFn);
+    };
   });
 
   return selectors;


### PR DESCRIPTION
**Description**

Auto generated selector hooks currently not support prevent re-render, i think it's better to implement it.

**Example**

```typescript
import shallow from 'zustand/shallow'

const repoStore = createStore('repo')({
  name: 'zustood ',
  stars: 0,
  middlewares: ['immer', 'devtools', 'persist']
})

// prevent unnecessary re-renders
// more see: https://docs.pmnd.rs/zustand/recipes#selecting-multiple-state-slices
useStore().repo.middlewares(shallow)

// or
useStore().repo.middlewares((prev, next) => prev.middlewares === next.middlewares)
```
