### PR TITLE
fix: update PersistOptions typing

### DIFF
--- a/.changeset/light-turkeys-live.md
+++ b/.changeset/light-turkeys-live.md
@@ -1,0 +1,5 @@
+---
+"@udecode/zustood": patch
+---
+
+fix: update `PersistOptions` typing

--- a/packages/zustood/src/types/PersistOptions.ts
+++ b/packages/zustood/src/types/PersistOptions.ts
@@ -6,6 +6,9 @@ export type StateStorage = {
 };
 export type StorageValue<S> = { state: S; version: number };
 
-export type PersistOptions<S> = _PersistOptions<S> & {
+type PersistOptionsWithoutName<S> = Omit<_PersistOptions<S>, 'name'>;
+
+export type PersistOptions<S> = PersistOptionsWithoutName<S> & {
   enabled?: boolean;
+  name?: string;
 };


### PR DESCRIPTION
**Description**
https://github.com/udecode/zustood/blob/main/packages/zustood/src/createStore.ts#L50

Since the name attribute in persist option has long been unnecessary, update the PersistOptions type accordingly.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->
